### PR TITLE
Fix the path to the phpunit executable

### DIFF
--- a/contributing/testing.md
+++ b/contributing/testing.md
@@ -5,7 +5,7 @@ installation and a checkout of the Rules module in the modules folder.
 
 #### PHPUnit
 
-    ./core/vendor/phpunit/phpunit/phpunit -c ./core/phpunit.xml.dist ./modules/rules
+    ./vendor/phpunit/phpunit/phpunit -c ./core/phpunit.xml.dist ./modules/rules
 
 #### Simpletest
 


### PR DESCRIPTION
I think the vendor path changed at some point for drupal8 from to core to the root directory, but the path to the phpunit executable was never updated.
This pull request fixes it.